### PR TITLE
Move all Ruby images to Debian Trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN . /usr/local/share/nvm/nvm.sh \
 
 RUN npm install -g heroku
 
+RUN corepack enable && corepack install -g yarn@^1
+
 RUN gem install rails pull-request
 
 COPY vendor/ngserver /opt/ngserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,10 @@ RUN echo "deb [trusted=yes] https://apt.postgresql.org/pub/repos/apt $(lsb_relea
 # Remove yarn apt source with expired signing key (yarn is available via corepack)
 RUN rm -f /etc/apt/sources.list.d/yarn.list
 
-# Install additional OS packages. Package names differ between Debian releases:
-# trixie dropped watchman and software-properties-common, and renamed libvips42 to libvips42t64.
-RUN if [ "$(lsb_release -cs)" = "trixie" ]; then \
-    PACKAGES="terraform gh libvips42t64 postgresql-client-17 python3-pip"; \
-  else \
-    PACKAGES="software-properties-common terraform gh libvips42 postgresql-client-17 python3-pip watchman"; \
-  fi && \
-  apt-get update && \
+# Install additional OS packages.
+RUN apt-get update && \
   export DEBIAN_FRONTEND=noninteractive && \
-  apt-get -y install --no-install-recommends $PACKAGES
+  apt-get -y install --no-install-recommends terraform gh libvips42t64 postgresql-client-17 python3-pip
 
 # Install AWS CLI based on the architecture
 RUN if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
@@ -55,10 +49,6 @@ RUN cd /opt/ngserver \
   && printf '#!/usr/bin/env bash\nexec /opt/ngserver/ngserver "$(pwd)" "$@"\n' > /usr/local/bin/ngserver \
   && chmod +x /usr/local/bin/ngserver
 
-RUN if [ "$(lsb_release -cs)" = "trixie" ]; then \
-    pip install --break-system-packages weasyprint; \
-  else \
-    pip install weasyprint; \
-  fi
+RUN pip install --break-system-packages weasyprint
 
 RUN npx playwright install-deps

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ VENDOR_DIR = File.join(__dir__, "vendor/ngserver")
 RUBY_IMAGES = {
   "3.3" => "ruby:3.3-trixie",
   "3.4" => "ruby:3.4-trixie",
-  "4.0" => "ruby:4-trixie",
+  "4.0" => "ruby:4.0-trixie",
 }.freeze
 
 task :push do

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,8 @@ require "dotenv/tasks"
 VENDOR_DIR = File.join(__dir__, "vendor/ngserver")
 
 RUBY_IMAGES = {
-  "3.3" => "ruby:1-3.3-bullseye",
-  "3.4" => "ruby:1-3.4-bullseye",
+  "3.3" => "ruby:3.3-trixie",
+  "3.4" => "ruby:3.4-trixie",
   "4.0" => "ruby:4-trixie",
 }.freeze
 


### PR DESCRIPTION
Let's move to Debian Trixie everywhere!

- Bullseye is already a few years old
- Bullseye doesn't get the fixed libvips ≥ 8.13 that's not susceptible to CVE-2026-66066 (Active Storage / libvips)
- We've been using trixie without problems on the Ruby 4 image (since they don't supply a Bullseye or a `1-3.4`-style image at all.)
- We can remove the conditionals between different operating systems.

I can release the new versions after the pull request is merged.